### PR TITLE
Bugfix: 오타 때문에 스토리북 description 안되는 것 수정

### DIFF
--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { string, number, oneOf } from 'prop-types';
 
 // as 사용해서 heading level을 유동적으로 사용
-const Heading = styled.h1`
+const StyledHeading = styled.h1`
   color: ${props => props.color};
   font-size: ${props => props.fontSize}rem;
   font-weight: ${props => props.fontWeight};
@@ -10,18 +10,24 @@ const Heading = styled.h1`
   background-color: ${props => props.backgroundColor};
 `;
 
+const Heading = ({ ...restProps }) => <StyledHeading {...restProps}></StyledHeading>;
+
+Heading.defaultProps = {
+  color: '#ddd',
+};
+
 Heading.propTypes = {
-  /** Heading에 적용 할 color를 설정합니다.*/
+  /** Heading에 적용 할 color를 설정합니다. */
   color: string,
-  /** Heading에 적용 할 fontSize 설정합니다.*/
+  /** Heading에 적용 할 fontSize 설정합니다. */
   fontSize: number,
-  /** Heading에 적용 할 fontWeight를 설정합니다.*/
+  /** Heading에 적용 할 fontWeight를 설정합니다. */
   fontWeight: number,
-  /** Heading에 적용 할 lineHeight를 설정합니다.*/
+  /** Heading에 적용 할 lineHeight를 설정합니다. */
   lineHeight: number,
   /** Heading에 적용 할 backgroundColor를 설정합니다. */
   backgroundColor: string,
-  /** Heading에 적용 할 Heading-level을 설정합니다.*/
+  /** Heading에 적용 할 Heading-level을 설정합니다. */
   as: oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).isRequired,
 };
 

--- a/src/components/Heading/Heading.stories.js
+++ b/src/components/Heading/Heading.stories.js
@@ -2,10 +2,10 @@ import Heading from './Heading';
 
 export default {
   title: 'Component/Heading',
-  componenet: Heading,
+  component: Heading,
   parameters: {
     docs: {
-      discription: {
+      description: {
         component: '**Heading** 컴포넌트는 as props를 받아서 h1~h6 중 하나를 사용 할 수 있습니다.',
       },
     },
@@ -13,11 +13,11 @@ export default {
   argTypes: {
     color: { control: 'color' },
     fontSize: { control: 'number' },
-    backgroundColor: { constrol: 'string' },
+    backgroundColor: { control: 'string' },
   },
 };
 
-const Template = args => <Heading {...args} />;
+const Template = args => <Heading {...args}>{args.children}</Heading>;
 
 export const ExampleHeading = Template.bind({});
 
@@ -25,5 +25,6 @@ ExampleHeading.args = {
   children: '김지원',
   color: '#FFFFFF',
   fontSize: 6.4,
+  //스토리북에서 default color가 흰색이라서 배경으로 검은색 했음.
   backgroundColor: '#000000',
 };


### PR DESCRIPTION
## 해당 이슈
Close # #21 

### 변경사항  
- 오타로 인해서 스토리북의 description이 작동하지 않는 현상을 고쳤음

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 스토리북을 추가하였는가?
