### PR TITLE
Bugfix: DND.stories.js 파일 내부에서 args에 id를 전해주지 않아 storybook에서의 접근성 violation 뜨는 문제

### DIFF
--- a/src/components/DND/DND.stories.js
+++ b/src/components/DND/DND.stories.js
@@ -15,3 +15,7 @@ export default {
 const Template = args => <DND {...args} />;
 
 export const ExampleDND = Template.bind({});
+
+ExampleDND.args = {
+  id: 'ex-1',
+};


### PR DESCRIPTION
## 해당 이슈
Close #72 

### 변경사항  
- ND.stories.js 파일 내부에서 args에 id를 전해주지 않아 storybook에서의 접근성 violation 뜨는 문제 args에 id프로퍼티 추가로 해결

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 스토리북을 추가하였는가?
