### PR TITLE
포트폴리오 수정 페이지에서 레이아웃 오류

### DIFF
--- a/src/components/ProjectDuration/ProjectDuration.js
+++ b/src/components/ProjectDuration/ProjectDuration.js
@@ -76,7 +76,7 @@ const ProjectDuration = ({ setFieldValue, vw, errors, editStartDate, editEndDate
           height="70px"
           display="flex"
           flexFlow="column"
-          margin="0"
+          margin={vw >= 768 ? '0' : '0 0 30px 0'}
           position="relative"
         >
           <StyledLabel $margin="0 0 10px 0" htmlFor="startDate">


### PR DESCRIPTION
## 해당 이슈
Close #

### 변경사항  
- 포트폴리오 수정 페이지에서 모바일 뷰로 바뀌었을때 프로젝트 기간의 위쪽 datepicker의 validation 메세지가 아래쪽 datepicker의 문구를 가리는 레이아웃적인 오류 발생해서 해결

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 스토리북을 추가하였는가?
