### PR TITLE
Bugfix: 댓글 작성 날짜가 제대로 표시되지 않는 이슈 발생

### DIFF
--- a/src/components/CommentAuthor/CommentAuthor.js
+++ b/src/components/CommentAuthor/CommentAuthor.js
@@ -31,13 +31,14 @@ const transferCreationDate = date => {
   const creationDate = parseInt((today.getTime() - registerDate.getTime()) / 1000);
 
   if (creationDate < 1) return '방금 전';
-  else if (creationDate < 60) return `${creationDate}초 전`;
-  else if (creationDate >= 60 && creationDate < 3600) return `${parseInt(creationDate / 60)}분 전`;
-  else if (creationDate >= 3600 && creationDate < 3600 * 24)
+  if (creationDate < 60) return `${creationDate}초 전`;
+  if (creationDate >= 60 && creationDate < 3600) return `${parseInt(creationDate / 60)}분 전`;
+  if (creationDate >= 3600 && creationDate < 3600 * 24)
     return `${parseInt(creationDate / 3600)}시간 전`;
-  else if (creationDate >= 3600 * 24 && today.getDate() - registerDate.getDate() < 8)
-    return `${today.getDate() - registerDate.getDate()}일 전`;
-  else return dateFormMaker(date);
+  if (creationDate >= 3600 * 24 && creationDate < 691200) {
+    return `${Math.round(creationDate / 60 / 60 / 24)}일 전`;
+  }
+  return dateFormMaker(date);
 };
 
 function CommentAuthor({


### PR DESCRIPTION
오늘의 날짜와 작성 날짜(일 수)를 빼는거기 때문에 월이 바뀌게 되면 에러가 발생 할 수밖에 없음, 예를 들어 5월28일 작성했는데 6월1일이 되면 1 - 28이 되어 -27일 전 이라는 결과가 나오게 된다.

밀리초를 직접 비교하여 해결

modified:   src/components/CommentAuthor/CommentAuthor.js

### 변경사항  
- CommentAuthor 컴포넌트 내부에서 시간을 파싱해주는 함수 변경

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/Devfolio-team/Devfolio-Client/wiki/%EC%BD%94%EB%94%A9-%EC%BB%A8%EB%B2%A4%EC%85%98)을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
- [ ] 변경사항이 효과적이거나 동작이 정상적이라는것을 보증하는 스토리북을 추가하였는가?
